### PR TITLE
Enable Day/Night Mode for OpenIPC hardware

### DIFF
--- a/code/base/hardware_camera.cpp
+++ b/code/base/hardware_camera.cpp
@@ -390,7 +390,9 @@ void hardware_camera_apply_all_majestic_camera_settings(camera_profile_parameter
    }
 
    hardware_camera_set_irfilter_off(pCameraParams->uFlags & CAMERA_FLAG_IR_FILTER_OFF);
-  
+
+   hardware_camera_set_daylight_off(pCameraParams->uFlags & CAMERA_FLAG_OPENIPC_DAYLIGHT_OFF);
+
    if ( bForceUpdate )
       hw_execute_bash_command_raw("killall -1 majestic", NULL);
 }
@@ -489,5 +491,20 @@ void hardware_camera_set_irfilter_off(int iOff)
          hw_execute_bash_command("gpio set 11", NULL);
          hw_execute_bash_command("gpio clear 10", NULL);
       }
+   }
+}
+
+void hardware_camera_set_daylight_off(int dlOff) {
+   if (!hardware_board_is_openipc(hardware_getBoardType()))
+      return;
+
+   // Daylight Off? Activate Night Mode
+   if (dlOff)
+   {
+      hw_execute_bash_command("curl localhost/night/on", NULL);
+   } 
+   else 
+   {
+      hw_execute_bash_command("curl localhost/night/off", NULL);
    }
 }

--- a/code/base/hardware_camera.h
+++ b/code/base/hardware_camera.h
@@ -15,3 +15,4 @@ int hardware_isCameraHDMI();
 void hardware_camera_apply_all_majestic_camera_settings(camera_profile_parameters_t* pCameraParams, bool bForceUpdate);
 void hardware_camera_apply_all_majestic_settings(Model* pModel, camera_profile_parameters_t* pCameraParams, int iVideoProfile, video_parameters_t* pVideoParams);
 void hardware_camera_set_irfilter_off(int iOff);
+void hardware_camera_set_daylight_off(int dlOff);

--- a/code/base/models.h
+++ b/code/base/models.h
@@ -18,6 +18,7 @@
 #define CAMERA_FLAG_FORCE_MODE_1 1
 #define CAMERA_FLAG_AWB_MODE_OLD ((u32)(((u32)0x01)<<1))
 #define CAMERA_FLAG_IR_FILTER_OFF ((u32)(((u32)0x01)<<2))
+#define CAMERA_FLAG_OPENIPC_DAYLIGHT_OFF ((u32)(((u32)0x01) << 3))
 
 typedef struct
 {
@@ -25,6 +26,7 @@ typedef struct
    // bit 0: force mode 1
    // bit 1: AWB mode old
    // bit 2: 1: turn IR Cut off
+   // bit 3: 1: turn off daylight mode for OpenIPC cameras, activate night mode
    u8 flip_image;
    u8 brightness; // 0...100
    u8 contrast;   // 0...100

--- a/code/r_central/menu/menu_vehicle_camera.cpp
+++ b/code/r_central/menu/menu_vehicle_camera.cpp
@@ -92,6 +92,7 @@ void MenuVehicleCamera::resetIndexes()
    m_IndexDayNight = -1;
    m_IndexVideoStab = m_IndexFlip = m_IndexReset = -1;
    m_IndexIRCut = -1;
+   m_IndexOpenIPCDayNight = -1;
 }
 
 void MenuVehicleCamera::addItems()
@@ -387,16 +388,23 @@ void MenuVehicleCamera::addItems()
 
 
    m_IndexIRCut = -1;
-   if ( g_pCurrentModel->isRunningOnOpenIPCHardware() )
-   if ( g_pCurrentModel->isActiveCameraOpenIPC() )
-   {
-      m_pItemsSelect[20] = new MenuItemSelect("IR Cut", "Turn IR cut filter on/off");  
-      m_pItemsSelect[20]->addSelection("On");
-      m_pItemsSelect[20]->addSelection("Off");
-      m_pItemsSelect[20]->setIsEditable();
-      m_pItemsSelect[20]->setMargin(fMargin);
-      m_IndexIRCut = addMenuItem(m_pItemsSelect[20]);
-   }
+   m_IndexOpenIPCDayNight = -1;
+   if (g_pCurrentModel->isRunningOnOpenIPCHardware())
+      if (g_pCurrentModel->isActiveCameraOpenIPC())
+      {
+         m_pItemsSelect[20] = new MenuItemSelect("IR Cut", "Turn IR cut filter on/off");
+         m_pItemsSelect[20]->addSelection("On");
+         m_pItemsSelect[20]->addSelection("Off");
+         m_pItemsSelect[20]->setIsEditable();
+         m_pItemsSelect[20]->setMargin(fMargin);
+         m_IndexIRCut = addMenuItem(m_pItemsSelect[20]);
+
+         m_pItemsSelect[21] = new MenuItemSelect("Day/Night Mode", "Sets the mode to daylight (color) or night (black and white).");
+         m_pItemsSelect[21]->addSelection("Daylight");
+         m_pItemsSelect[21]->addSelection("Night B/W");
+         m_pItemsSelect[21]->setMargin(fMargin);
+         m_IndexOpenIPCDayNight = addMenuItem(m_pItemsSelect[21]);
+      }
 
    m_IndexReset = addMenuItem(new MenuItem("Reset Profile", "Resets the current vehicle's camera paramters (brightness, contrast, etc) to the default values for the current profile."));
    m_pMenuItems[m_IndexReset]->setMargin(fMargin);
@@ -675,6 +683,16 @@ void MenuVehicleCamera::sendCameraParams(int itemIndex, bool bQuick)
          cparams.profiles[iProfile].uFlags |= CAMERA_FLAG_IR_FILTER_OFF;
       bSendToVehicle = true;
    }
+
+   if (-1 != m_IndexOpenIPCDayNight)
+      if ((m_IndexOpenIPCDayNight == itemIndex) || (itemIndex == -1))
+      {
+         if (0 == m_pItemsSelect[20]->getSelectedIndex())
+            cparams.profiles[iProfile].uFlags &= ~CAMERA_FLAG_OPENIPC_DAYLIGHT_OFF;
+         else
+            cparams.profiles[iProfile].uFlags |= CAMERA_FLAG_OPENIPC_DAYLIGHT_OFF;
+         bSendToVehicle = true;
+      }
 
    if ( (m_IndexSharpness != -1 && m_IndexSharpness == itemIndex ) || itemIndex == -1 )
    if ( m_pItemsSlider[3] != NULL )
@@ -983,6 +1001,10 @@ void MenuVehicleCamera::onSelectItem()
    if ( m_IndexIRCut != -1 )
    if ( m_IndexIRCut == m_SelectedIndex )
       sendCameraParams(-1, false);
+
+   if (m_IndexOpenIPCDayNight != -1)
+      if (m_IndexOpenIPCDayNight == m_SelectedIndex)
+         sendCameraParams(-1, false);
 
    if ( m_IndexCalibrateHDMI == m_SelectedIndex )
    {

--- a/code/r_central/menu/menu_vehicle_camera.cpp
+++ b/code/r_central/menu/menu_vehicle_camera.cpp
@@ -402,6 +402,7 @@ void MenuVehicleCamera::addItems()
          m_pItemsSelect[21] = new MenuItemSelect("Day/Night Mode", "Sets the mode to daylight (color) or night (black and white).");
          m_pItemsSelect[21]->addSelection("Daylight");
          m_pItemsSelect[21]->addSelection("Night B/W");
+         m_pItemsSelect[21]->setIsEditable();
          m_pItemsSelect[21]->setMargin(fMargin);
          m_IndexOpenIPCDayNight = addMenuItem(m_pItemsSelect[21]);
       }

--- a/code/r_central/menu/menu_vehicle_camera.cpp
+++ b/code/r_central/menu/menu_vehicle_camera.cpp
@@ -688,7 +688,7 @@ void MenuVehicleCamera::sendCameraParams(int itemIndex, bool bQuick)
    if (-1 != m_IndexOpenIPCDayNight)
       if ((m_IndexOpenIPCDayNight == itemIndex) || (itemIndex == -1))
       {
-         if (0 == m_pItemsSelect[20]->getSelectedIndex())
+         if (0 == m_pItemsSelect[21]->getSelectedIndex())
             cparams.profiles[iProfile].uFlags &= ~CAMERA_FLAG_OPENIPC_DAYLIGHT_OFF;
          else
             cparams.profiles[iProfile].uFlags |= CAMERA_FLAG_OPENIPC_DAYLIGHT_OFF;

--- a/code/r_central/menu/menu_vehicle_camera.h
+++ b/code/r_central/menu/menu_vehicle_camera.h
@@ -43,6 +43,7 @@ class MenuVehicleCamera: public Menu
       int m_IndexDayNight;
       int m_IndexVideoStab, m_IndexFlip, m_IndexReset;
       int m_IndexIRCut;
+      int m_IndexOpenIPCDayNight;
       int m_IndexCalibrateHDMI;
 
       bool m_bDidAnyLiveUpdates;

--- a/code/r_vehicle/ruby_rx_commands.cpp
+++ b/code/r_vehicle/ruby_rx_commands.cpp
@@ -1733,6 +1733,12 @@ bool process_command(u8* pBuffer, int length)
             hardware_camera_set_irfilter_off(uNewFlags & CAMERA_FLAG_IR_FILTER_OFF);
             return true;
          }
+
+         if ((oldFlags & CAMERA_FLAG_OPENIPC_DAYLIGHT_OFF) != (uNewFlags & CAMERA_FLAG_OPENIPC_DAYLIGHT_OFF))
+         {
+            hardware_camera_set_daylight_off(uNewFlags & CAMERA_FLAG_OPENIPC_DAYLIGHT_OFF);
+            return true;
+         }
       }
 
       bool bSentUsingPipe = false;


### PR DESCRIPTION
- Added menu to switch between Daylight (color) and Night (B/W) mode

- Handle majestic night mode settings based on menu selection