### PR TITLE
Fix Radxa DVR playback speed and recording FPS metadata

### DIFF
--- a/code/r_central/video_playback.cpp
+++ b/code/r_central/video_playback.cpp
@@ -112,6 +112,20 @@ void video_playback_play_file(const char* szVideoInfoFile)
    if ( s_iMSPOSDCols > 64 )
       s_iMSPOSDCols = 64;
 
+   if ( (iFPS < 5) || (iFPS > 120) )
+   {
+      if ( (NULL != g_pCurrentModel) && (g_pCurrentModel->video_params.iVideoFPS >= 5) && (g_pCurrentModel->video_params.iVideoFPS <= 120) )
+         iFPS = g_pCurrentModel->video_params.iVideoFPS;
+      else
+         iFPS = 30;
+      log_softerror_and_alarm("VideoPlayback: Clamped invalid FPS from info file to %d", iFPS);
+   }
+   else if ( (NULL != g_pCurrentModel) && (g_pCurrentModel->video_params.iVideoFPS >= 5) && (iFPS > g_pCurrentModel->video_params.iVideoFPS + 10) )
+   {
+      log_softerror_and_alarm("VideoPlayback: FPS %d from info file is much higher than model FPS %d, using model FPS", iFPS, g_pCurrentModel->video_params.iVideoFPS);
+      iFPS = g_pCurrentModel->video_params.iVideoFPS;
+   }
+
    log_line("VideoPlayback: Read info file: wxh: %dx%d, type: %d, fc: %d, osd font: %d, cols/rows: %d/%d",
        iWidth, iHeight, iType, s_iMSPOSDFCType, s_iMSPOSDFontType, s_iMSPOSDCols, s_iMSPOSDRows);
    fclose(fd);
@@ -127,6 +141,8 @@ void video_playback_play_file(const char* szVideoInfoFile)
 
    #ifdef HW_PLATFORM_RADXA
    snprintf(szComm, sizeof(szComm)/sizeof(szComm[0]), "./%s -file %s%s -fps %d", VIDEO_PLAYER_OFFLINE, FOLDER_MEDIA, szFile, iFPS);
+   if ( iType == VIDEO_TYPE_H265 )
+      strcat(szComm, " -h265");
    #endif
 
    if ( g_pControllerSettings->iCoresAdjustment )

--- a/code/r_player/ruby_player_radxa.cpp
+++ b/code/r_player/ruby_player_radxa.cpp
@@ -137,6 +137,31 @@ void _signal_play_file_finished()
       log_softerror_and_alarm("Failed to open and signal semaphore %s", SEMAPHORE_VIDEO_FILE_PLAYBACK_FINISHED);
 }
 
+static bool _player_is_h264_vcl_nal(u32 uNALType)
+{
+   return (uNALType == 1) || (uNALType == 5);
+}
+
+static bool _player_is_h265_vcl_nal(u32 uNALType)
+{
+   return uNALType <= 31;
+}
+
+static void _player_pace_frame(u32* puFrameCount, u32* puPlaybackStartMs)
+{
+   if ( g_iFileFPS < 1 )
+      return;
+
+   if ( 0 == *puPlaybackStartMs )
+      *puPlaybackStartMs = get_current_timestamp_ms();
+
+   (*puFrameCount)++;
+   u32 uTargetMs = *puPlaybackStartMs + ((*puFrameCount) * 1000) / (u32)g_iFileFPS;
+   u32 uNow = get_current_timestamp_ms();
+   if ( uTargetMs > uNow )
+      hardware_sleep_ms(uTargetMs - uNow);
+}
+
 void _do_player_mode()
 {
    ControllerSettings* pCS = get_ControllerSettings();
@@ -202,7 +227,8 @@ void _do_player_mode()
    u32 uCurrentParseToken = 0x11111111;
    u32 uNALType = 0;
    u32 uPrevNALType = 0;
-   u32 uTimeLastFrame = 0;
+   u32 uFrameCount = 0;
+   u32 uPlaybackStartMs = 0;
 
 
    while ( (nRead > 0) && (!g_bQuit) )
@@ -213,21 +239,31 @@ void _do_player_mode()
       if ( nRead <= 0 )
          break;
       
-      // Detect end of a NAL
+      // Detect NAL boundaries and pace playback per video frame
       u8* pTmp = &(uBuffer[0]);
       for( int i=0; i<nRead; i++ )
       {
          uCurrentParseToken = (uCurrentParseToken << 8) | (*pTmp);
          pTmp++;
-         if ( uCurrentParseToken == 0x00000001 )
-         if ( i<(nRead-1) )
+         if ( uCurrentParseToken != 0x00000001 )
+            continue;
+         if ( i >= (nRead-1) )
+            continue;
+
+         if ( g_bUseH265Decoder )
          {
-            uNALType = (*pTmp) &0x1F;
+            uNALType = ((*pTmp) >> 1) & 0x3F;
+            if ( ! _player_is_h265_vcl_nal(uNALType) )
+               continue;
+
+            _player_pace_frame(&uFrameCount, &uPlaybackStartMs);
+         }
+         else
+         {
+            uNALType = (*pTmp) & 0x1F;
 
             if ( (uPrevNALType == 5) && (uNALType != 5) )
-            {
                g_iFileDetectedSlices = g_iFileTempSlices;
-            }
 
             if ( uPrevNALType == uNALType )
                g_iFileTempSlices++;
@@ -236,23 +272,12 @@ void _do_player_mode()
 
             uPrevNALType = uNALType;
 
+            if ( ! _player_is_h264_vcl_nal(uNALType) )
+               continue;
+            if ( (g_iFileTempSlices % g_iFileDetectedSlices) != 0 )
+               continue;
 
-            if ( (g_iFileTempSlices % g_iFileDetectedSlices) == 0 )
-            if ( ! parser_h264_is_signaling_nal(uNALType) )
-            {
-               u32 uTimeNow = get_current_timestamp_ms();
-
-               //long int miliSecs = (1000/g_iFileFPS);
-               // OpenIPC generates faster FPS as IFrames are not part of computation
-               long int miliSecs = (1000/(g_iFileFPS-4));
-               miliSecs = miliSecs - (uTimeNow - uTimeLastFrame);
-               uTimeLastFrame = uTimeNow;
-
-               if ( miliSecs > 0 )
-               {
-                  hardware_sleep_ms(miliSecs);
-               }
-            }
+            _player_pace_frame(&uFrameCount, &uPlaybackStartMs);
          }
       }
 

--- a/code/r_station/processor_rx_video.cpp
+++ b/code/r_station/processor_rx_video.cpp
@@ -401,14 +401,35 @@ int ProcessorRxVideo::getVideoHeight()
 int ProcessorRxVideo::getVideoFPS()
 {
    int iFPS = 0;
+   int iDetectedFPS = 0;
    if ( -1 != m_iIndexVideoDecodeStats )
-      iFPS = g_SM_VideoDecodeStats.video_streams[m_iIndexVideoDecodeStats].iCurrentVideoTxSourceFPS;
-   if ( 0 == iFPS )
    {
-      Model* pModel = findModelWithId(m_uVehicleId, 177);
-      if ( NULL != pModel )
-         iFPS = pModel->video_params.iVideoFPS;
+      iFPS = g_SM_VideoDecodeStats.video_streams[m_iIndexVideoDecodeStats].iCurrentVideoTxSourceFPS;
+      iDetectedFPS = g_SM_VideoDecodeStats.video_streams[m_iIndexVideoDecodeStats].iDetectedFPS;
    }
+
+   Model* pModel = findModelWithId(m_uVehicleId, 177);
+   int iModelFPS = 0;
+   if ( NULL != pModel )
+      iModelFPS = pModel->video_params.iVideoFPS;
+
+   // iCurrentVideoTxSourceFPS comes from the air unit and can be wrong (e.g. 83 instead of 25).
+   // Prefer locally detected FPS when it disagrees significantly with the reported value.
+   if ( iDetectedFPS > 0 )
+   {
+      if ( (iFPS <= 0) || (iFPS > 120) || (abs(iFPS - iDetectedFPS) > 15) )
+         iFPS = iDetectedFPS;
+   }
+
+   if ( (iFPS <= 0) || (iFPS > 120) )
+   {
+      if ( iModelFPS > 0 )
+         iFPS = iModelFPS;
+   }
+
+   if ( iFPS <= 0 )
+      iFPS = 30;
+
    return iFPS;
 }
 

--- a/code/r_station/rx_video_recording.cpp
+++ b/code/r_station/rx_video_recording.cpp
@@ -448,6 +448,17 @@ void* _thread_video_recording(void *argument)
       return NULL;
    }
 
+   for( int i=0; i<MAX_VIDEO_PROCESSORS; i++ )
+   {
+      if( NULL == g_pVideoProcessorRxList[i] )
+         break;
+      if ( g_pCurrentModel->uVehicleId != g_pVideoProcessorRxList[i]->m_uVehicleId )
+         continue;
+      s_iRecordingFPS = g_pVideoProcessorRxList[i]->getVideoFPS();
+      log_line("[VideoRecording-Th] Final recording FPS for info file: %d", s_iRecordingFPS);
+      break;
+   }
+
    if ( ! _recording_write_info_file(uDurrationMs) )
    {
       _recording_cleanp_temp_recording_data();


### PR DESCRIPTION
## Summary

Fixes Radxa ground station DVR playback running ~4× too fast when reviewing recordings from the Media & Storage menu. Exported files were already correct; only on-device preview was affected.

## Root cause

Three compounding bugs:

1. **`getVideoFPS()`** trusted bogus Tx source FPS from the air unit (e.g. 83 fps logged while stream was ~25 fps), writing wrong values into recording `.info` files
2. **`ruby_player_radxa.cpp`** used H.264 NAL parsing and an old `FPS-4` pacing hack; H.265 VCL detection and wall-clock pacing were missing
3. **`video_playback.cpp`** did not clamp invalid FPS or pass `-h265` for H.265 recordings on Radxa

## Changes

- `processor_rx_video.cpp` — prefer detected FPS when Tx source FPS is bogus
- `rx_video_recording.cpp` — refresh FPS before final `.info` write on stop
- `ruby_player_radxa.cpp` — H.265 VCL detection + wall-clock frame pacing; remove FPS-4 hack
- `video_playback.cpp` — clamp invalid FPS; pass `-h265` for H.265 on Radxa

## Testing

Tested on **Radxa Zero 3E** with RubyFPV **11.8** (b-11801). DVR playback now runs at correct speed.

Closes #60
Closes #76
Closes #80
